### PR TITLE
new(meeting-notes): add missing notes for call on 13th May 2020

### DIFF
--- a/meeting-notes/2020-05-13.md
+++ b/meeting-notes/2020-05-13.md
@@ -1,0 +1,69 @@
+# Falco Community Call
+
+[More Information](https://github.com/falcosecurity/community)
+[Zoom Link](https://zoom.us/my/cncffalcoproject) 
+[Recording](https://youtu.be/e5Lxr8Vqkeg)
+
+## 2020-05-13
+
+### MC
+
+- Spencer Krum
+
+### Who joined
+
+- Leonardo Di Donato ([@leodido](https://github.com/leodido))
+- Leonardo Grasso ([@leogr](https://github.com/leogr))
+- Kris Nóva ([@kris-nova](https://github.com/kris-nova))
+- Lorenzo Fontana ([@fntlnz](https://github.com/fntlnz))
+- Spencer Krum ([@nibalizer](https://github.com/nibalizer))
+- Grzegorz Nosek
+- Thomas Labarussias ([@issif](https://github.com/issif)))
+- Maddie Jones ([@Maddieg91](https://github.com/maddyg91))
+- Yakov Zaytsev ([@ysz](https://github.com/ysz))
+
+### This week highlights
+
+- [nova] [pdig](https://github.com/falcosecurity/pdig)
+    - into `falcosecurity` org now!
+    - prow setup ready: https://github.com/falcosecurity/test-infra/pull/126
+- [nova] [falco-trace](https://github.com/kris-nova/falco-trace)
+- [nova/leodido/fntlnz/leogr] Finally wrote down the SoA of current Falco artifacts, and the future plan
+    - Proposal: https://github.com/falcosecurity/falco/pull/1184
+    - PRs already in that direction: #1192, #1196, #1202, #1172, etc.
+
+### Agenda
+
+- [fntlnz/leodido] Update on the Falco profiler
+    - FPRO file format, want to propose a different 4-chars file extension/identifier?
+    - Proposal [here](https://github.com/falcosecurity/falco/issues/1204)
+        - Go vote here => https://twitter.com/leodido/status/1260526021369004033
+    - TODO: Get maintainers call for privacy/security go-forward issues\
+        - How do users securely give us logs/vulns/FPRO files
+        - CNCF Slack is coming (TM), has poor guarantees about privacy of messages (usually a good thing)
+        - Everyone GPG
+        - Build upon this (https://github.com/falcosecurity/falco/security/policy) ? 
+
+
+- [leogr] Cleanup update
+    - `/examples` moved to `contrib` [falco#1191](https://github.com/falcosecurity/falco/pull/1191)
+    - `/integrations` moved to `contrib` [falco#1157](https://github.com/falcosecurity/falco/pull/1157)
+    - `falcosecurity/falco:minimal` removed [falco#1196](https://github.com/falcosecurity/falco/pull/1196)
+        - this and the `slim` will be replaced with `falco-no-driver` image
+
+- [leogr] new images
+    - as per [this proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200506-artifacts-scope-part-2.md#images)
+    - WIP `falcosecurity/falco-no-driver` (basically the old `minimal`)
+    - `falcosecurity/falco-driver-loader` (basically `stable` with `falco-driver-loader` as entrypoint)
+        - [falco#1172](https://github.com/falcosecurity/falco/pull/1172)
+        - [falco#1192](https://github.com/falcosecurity/falco/pull/1192)
+
+- [leogr] `falco-driver-loader` improvements
+    - break apart logic WIP [falco#1200](https://github.com/falcosecurity/falco/pull/1200)
+    - regression test added also for bin package [falco#1202](https://github.com/falcosecurity/falco/pull/1202)
+    - add integration tests WIP
+
+### Closing
+
+- **MC Next Call**: Leo
+- **Next Release**: Lore/Grasso - May 18th


### PR DESCRIPTION
Fixes #91 

This commit adds the notes for the community call on 13th May 2020 (led by @nibalizer) which were missing.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>