### PR TITLE
docs(README.md): update slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ Regardless if you are interested in starting a new call, or running an existing 
 
 ### Resources
 
- - [Join the Falco slack](https://slack.sysdig.com)
+ - Join the #falco channel on the [Kubernetes Slack](https://slack.k8s.io)
  - [Join the Falco mailing list](https://lists.cncf.io/g/cncf-falco-dev)
  - [Read the Falco documentation](https://falco.org/docs/)


### PR DESCRIPTION
Since https://github.com/kubernetes/community/pull/4792 has been closed and https://github.com/falcosecurity/community/pull/95 is on hold, but we still have the old link in the main README, I believe we have to update this ASAP.

/cc @leodido 